### PR TITLE
i13 - support ajax data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ popular [DataTables](https://github.com/DataTables/DataTables) plugin.
 DataTables does not support tree data by default, so this plugin adds
 that support.
 
+Please note that TreeTables does *not* support server-side processing.
+
 ![Screenshot of plugin in use](screenshot.png)
 
 ## Installation options
@@ -56,7 +58,7 @@ Data provided to the table must include the following fields:
 * tt_parent: number - the key of this row's parent row
 
 ## Options
-TreeTable options are all DataTable options plus:
+TreeTable options are most DataTable options plus:
 * collapsed: bool - whether to start with all child rows collapsed
 
 ```
@@ -119,6 +121,11 @@ To collapse all rows:
     $('#myTable').data('treeTable')
                     .collapseAllRows()
                     .redraw();
+
+## Ajax data sources
+TreeTables has minimal support for ajax data sources. The `ajax` option can be used as per the
+[DataTables documentation](https://datatables.net/reference/option/ajax), but it does *not* support server-side processing,
+ and it does *not* support the ajax related API methods: `ajax.json()`, `ajax.reload()`, `ajax.url()`
 
 ## Examples
 See [examples/README.md](examples/README.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,5 @@ styling can be customised
 
 `example-3.html` is styled with Bootstrap and also demonstrates how
 to implement buttons which collapse/expand all rows when clicked.
+
+`example-4.html` shows an example using an ajax data source

--- a/examples/example-4.html
+++ b/examples/example-4.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="../node_modules/datatables.net-dt/css/jquery.dataTables.css"/>
+    <link rel="stylesheet" href="../tree-table.css"/>
+</head>
+<body>
+<table id="test-table" width="100%">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th>Salary</th>
+    </tr>
+    </thead>
+</table>
+</body>
+<script src="../node_modules/jquery/dist/jquery.js"></script>
+<script src="../node_modules/datatables.net/js/jquery.dataTables.js"></script>
+<script src="../treeTable.js"></script>
+<script>
+    $(document).ready(function () {
+
+        $('#test-table').treeTable({
+            "ajax": "fakeData.json",
+            "collapsed": false,
+            "columns": [
+                {
+                    "data": "name"
+                },
+                {
+                    "data": "salary",
+                    render: function (data) {
+                        return "£" + data;
+                    }
+                }
+            ],
+            "order": [[1, 'desc']]
+        });
+
+    })
+</script>
+</html>

--- a/examples/fakeData.json
+++ b/examples/fakeData.json
@@ -1,0 +1,34 @@
+{
+  "data": [
+    {
+      "tt_key": 1,
+      "tt_parent": 0,
+      "name": "CEO",
+      "salary": 1000000
+    },
+    {
+      "tt_key": 2,
+      "tt_parent": 1,
+      "name": "CTO",
+      "salary": 110000
+    },
+    {
+      "tt_key": 3,
+      "tt_parent": 2,
+      "name": "Front-end developer",
+      "salary": 60000
+    },
+    {
+      "tt_key": 4,
+      "tt_parent": 2,
+      "name": "Back-end developer",
+      "salary": 65000
+    },
+    {
+      "tt_key": 5,
+      "tt_parent": 1,
+      "name": "CFO",
+      "salary": 100000
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treetables",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "jquery plugin extending jquery-datatables to support tree data",
   "keywords": [
     "DataTables",

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -63,3 +63,118 @@ test("can render with null data", () => {
     });
 
 });
+
+test("can render ajax data from simple ajax source", (done) => {
+
+    const fakeData = {
+        "data": [
+            {"tt_key": 1, "tt_parent": 0, "name": "e"},
+            {"tt_key": 2, "tt_parent": 0, "name": "f"}
+        ]
+    };
+
+    $.ajax = jest.fn().mockImplementation((params) => {
+        return Promise.resolve(params.success(fakeData));
+    });
+
+    const $table = $(document.createElement('table'));
+    $table.append($(headers));
+
+    $table.treeTable({
+        ajax: "fakeData.json",
+        columns: [
+            {data: "name"}
+        ],
+        collapsed: false,
+        order: [1, "desc"]
+    });
+
+    setTimeout(() => {
+        expect($.ajax.mock.calls.length).toBe(1);
+        expect($.ajax.mock.calls[0][0].url).toBe("fakeData.json");
+        const $dummy = $("#dummy-wrapper table");
+        const oSettings = $dummy.dataTable().fnSettings();
+        $dummy.trigger("xhr.dt", [oSettings, oSettings.json]);
+        setTimeout(() => {
+            expect($($table.find("tbody tr")[0]).find("td")[1].textContent).toBe("f");
+            expect($($table.find("tbody tr")[1]).find("td")[1].textContent).toBe("e");
+            done();
+        });
+    });
+
+});
+
+test("can render ajax data from object ajax source", (done) => {
+
+    const fakeData = {
+        "test": [
+            {"tt_key": 1, "tt_parent": 0, "name": "c"},
+            {"tt_key": 2, "tt_parent": 0, "name": "d"}
+        ]
+    };
+
+    $.ajax = jest.fn().mockImplementation((params) => {
+        return Promise.resolve(params.success(fakeData));
+    });
+
+    const $table = $(document.createElement('table'));
+    $table.append($(headers));
+
+    $table.treeTable({
+        ajax: {url: "fakeData.json", dataSrc: "test"},
+        columns: [
+            {data: "name"}
+        ],
+        collapsed: false,
+        order: [1, "desc"]
+    });
+
+    setTimeout(() => {
+        expect($.ajax.mock.calls.length).toBe(1);
+        expect($.ajax.mock.calls[0][0].url).toBe("fakeData.json");
+        const $dummy = $("#dummy-wrapper table");
+        const oSettings = $dummy.dataTable().fnSettings();
+        $dummy.trigger("xhr.dt", [oSettings, oSettings.json]);
+        setTimeout(() => {
+            expect($($table.find("tbody tr")[0]).find("td")[1].textContent).toBe("d");
+            expect($($table.find("tbody tr")[1]).find("td")[1].textContent).toBe("c");
+            done();
+        });
+    });
+
+});
+
+test("can render ajax data from function ajax source", (done) => {
+
+    const fakeData = {
+        "data": [
+            {"tt_key": 1, "tt_parent": 0, "name": "a"},
+            {"tt_key": 2, "tt_parent": 0, "name": "b"}
+        ]
+    };
+
+    const $table = $(document.createElement('table'));
+    $table.append($(headers));
+
+    $table.treeTable({
+        ajax: () => fakeData,
+        columns: [
+            {data: "name"}
+        ],
+        collapsed: false,
+        order: [1, "desc"]
+    });
+
+    setTimeout(() => {
+        const $dummy = $("#dummy-wrapper table");
+        const oSettings = $dummy.dataTable().fnSettings();
+        $dummy.trigger("xhr.dt", [oSettings, oSettings.jqXHR]);
+        setTimeout(() => {
+            expect($($table.find("tbody tr")[0]).find("td")[1].textContent).toBe("b");
+            expect($($table.find("tbody tr")[1]).find("td")[1].textContent).toBe("a");
+            done();
+        });
+
+    });
+
+});

--- a/treeTable.js
+++ b/treeTable.js
@@ -130,9 +130,11 @@
             this.$dummy.on('xhr.dt', function (e, settings, json, xhr) {
                 self.$dummy.DataTable().destroy();
                 self.$dummy.parent().remove();
-                options.data = $.fn.dataTableExt.internal._fnAjaxDataSrc(settings, json);
-                options.ajax = null;
-                self.init(options);
+                if (json != null) {
+                    options.data = $.fn.dataTableExt.internal._fnAjaxDataSrc(settings, json);
+                    options.ajax = null;
+                    self.init(options);
+                }
             });
         }
     };

--- a/treeTable.js
+++ b/treeTable.js
@@ -120,6 +120,8 @@
         if (options.data) {
             this.init(options);
         } else if (options.ajax) {
+            // here create a dummy DataTable using the provided ajax source so that we can use
+            // DataTables internal logic to retrieve json and handle any ajax errors
             this.$dummy = $("<table></table>");
             this.$dummyWrapper = $('<div id="dummy-wrapper" style="display:none"></div>');
 
@@ -131,6 +133,8 @@
                 self.$dummy.DataTable().destroy();
                 self.$dummy.parent().remove();
                 if (json != null) {
+                    // calling this internal method retrieves data from the json in accordance with
+                    // provided DataTable ajax options - https://datatables.net/reference/option/ajax
                     options.data = $.fn.dataTableExt.internal._fnAjaxDataSrc(settings, json);
                     options.ajax = null;
                     self.init(options);


### PR DESCRIPTION
This PR adds minimal support for ajax data sources - that is, support for the initial provision of an ajax data source, without support for full server-side processing or for ajax related API methods.

Closes #13 although not #17 