### PR TITLE
mrc-1925 Improve performance with large number of rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treetables",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "jquery plugin extending jquery-datatables to support tree data",
   "keywords": [
     "DataTables",

--- a/tests/performance.test.js
+++ b/tests/performance.test.js
@@ -105,11 +105,11 @@ test('100 parent rows with 5 children each', () => {
     testRenderExpandAndCollapse(fakeData, 500)
 });
 
-test('1000 parent rows with 5 children each', () => {
+test('4000 parent rows with 5 children each', () => {
 
     let i = 1;
     const fakeData = [];
-    while (i < 6000) {
+    while (i < 24000) {
         fakeData.push(
             {"tt_key": i, "tt_parent": 0, name: "parent" + i},
             {"tt_key": i + 1, "tt_parent": i, name: "child" + i + 1},
@@ -120,7 +120,7 @@ test('1000 parent rows with 5 children each', () => {
         i = i + 5
     }
 
-    testRenderExpandAndCollapse(fakeData, 3000, 500)
+    testRenderExpandAndCollapse(fakeData, 6000, 750)
 });
 
 test('40 parent rows with 3 generations of 2 children each', () => {

--- a/treeTable.js
+++ b/treeTable.js
@@ -106,8 +106,17 @@
     };
 
     function createDataDict(data) {
+        const children = data.reduce(function (map, obj) {
+            if (obj.tt_parent) {
+                if (!map[obj.tt_parent]) {
+                    map[obj.tt_parent] = [];
+                }
+                map[obj.tt_parent].push(obj);
+            }
+            return map;
+        }, {});
         return data.reduce(function (map, obj) {
-            obj.children = data.filter((d) => d["tt_parent"] === obj.tt_key);
+            obj.children = children[obj.tt_key] || [];
             obj.hasChild = obj.children.length > 0;
             map[obj.tt_key] = obj;
             return map;


### PR DESCRIPTION
* Remove inner loop from construction of data dictionary, which V8 (Chrome, Edge) doesn't seem to optimise very efficiently in comparison to SpiderMonkey (Firefox)
* In Edge on my machine this reduces time to render the the ncov reports list from ~25 seconds to ~2 seconds (preceded by ~5 seconds to receive the data), making performance very similar to Firefox